### PR TITLE
fix: multiple bug fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "nibabel",
     "antspyx",
     "nireports",
+    "nitransforms",
 ]
 
 [project.scripts]

--- a/src/skullduggery/run.py
+++ b/src/skullduggery/run.py
@@ -97,7 +97,7 @@ def parse_args():
         default= [{"datatype": "anat"}],
         help="path to or inline json with pybids filters to select all images to deface",
     )
-    parser.add_argument("--deface-sensitive", help="select series to deface using git-annex metadata string")
+    parser.add_argument("--deface-sensitive", action="store_true", help="select series to deface using git-annex metadata string")
     parser.add_argument(
         "--debug",
         dest="debug_level",

--- a/src/skullduggery/utils.py
+++ b/src/skullduggery/utils.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-import nibabel as nb
 import logging
-import json
+from typing import Literal, cast
+
+import nibabel as nb
 
 
 def output_debug_images(ref, moving, affine):
@@ -32,11 +33,26 @@ def output_debug_images(ref, moving, affine):
 def get_age_and_unit(layout, subject, session=None):
     participants_tsv = layout.get(suffix='participants', extension='.tsv')[0]
     participants_df = participants_tsv.get_df()
-    session_df_mask = participants_df['participant_id'] == f"sub-{subject}"
-    if session:
-        session_df_mask = session_df_mask & participants_df['session_id'] == f"ses-{session}"
-    participant_age = participants_df.loc[session_df_mask, 'age'].values[0]
+    participant_mask = participants_df['participant_id'] == f"sub-{subject}"
+    if session and 'session_id' in participants_df.columns:
+        participant_mask = participant_mask & (participants_df['session_id'] == f"ses-{session}")
+
+    if 'age' not in participants_df.columns:
+        logging.warning('participants.tsv does not contain an age column')
+        return None
+
+    matching_rows = participants_df.loc[participant_mask, 'age']
+    if matching_rows.empty:
+        logging.warning('no participant age found for sub-%s', subject)
+        return None
+
+    participant_age = float(matching_rows.iloc[0])
     age_unit = _get_age_units(participants_tsv.get_metadata())
+    if not age_unit:
+        logging.warning('participants.tsv metadata does not define supported age units')
+        return None
+
+    return participant_age, age_unit
 
 ### from nibabies
 
@@ -46,13 +62,16 @@ SUPPORTED_AGE_UNITS = (
     'years',
 )
 
-def _get_age_units(data: dict) -> ty.Literal['weeks', 'months', 'years', False]:
+AgeUnit = Literal['weeks', 'months', 'years']
+
+def _get_age_units(data: dict) -> AgeUnit | bool:
 
     units = data.get('age', {}).get('Units', '')
     if not isinstance(units, str):
         # Multiple units consfuse us
         return False
 
-    if units.lower() in SUPPORTED_AGE_UNITS:
-        return units.lower()
+    normalized_units = units.lower()
+    if normalized_units in SUPPORTED_AGE_UNITS:
+        return cast(AgeUnit, normalized_units)
     return False


### PR DESCRIPTION
- Fix age lookup for datasets without session-level participant metadata 
- Only apply session filtering when session_id exists in participants.tsv
- Fix the boolean mask construction for session filtering
- Return None with warnings when age or supported age units are missing
- Return the resolved (age, age_unit) tuple correctly
- Clean up the helper typing for supported age units

Closes #42 