### PR TITLE
fix: add optional report_dir parameter to generate_figure_path

### DIFF
--- a/src/skullduggery/report.py
+++ b/src/skullduggery/report.py
@@ -83,7 +83,7 @@ def generate_deface_mosaic_report(masked_image: SpatialImage, warped_mask: Spati
     )
 
 
-def generate_figure_path(layout: bids.BIDSLayout, series: bids.layout.BIDSFile, desc: str) -> Path:
+def generate_figure_path(layout: bids.BIDSLayout, series: bids.layout.BIDSFile, desc: str, report_dir: Path | None = None) -> Path:
     """Generate BIDS-compliant path for a figure file.
 
     Constructs a BIDS-formatted path for saving figures (SVGs) derived from
@@ -93,6 +93,8 @@ def generate_figure_path(layout: bids.BIDSLayout, series: bids.layout.BIDSFile, 
         layout: PyBIDS layout of the dataset.
         series: BIDSFile object of the source anatomical series.
         desc: Description label for the figure (e.g., "mask", "reg").
+        report_dir: Optional directory root for figures. If provided, figures
+            are placed under this directory instead of the dataset root.
 
     Returns:
         Path: Complete path for the figure file in BIDS structure.
@@ -117,7 +119,8 @@ def generate_figure_path(layout: bids.BIDSLayout, series: bids.layout.BIDSFile, 
     path = bids.layout.layout.build_path(entities, path_patterns=default_path_patterns)
     if not path:
         raise RuntimeError(f"Cannot generate a figure path for {entities}")
-    return layout._root / path
+    root = Path(report_dir) if report_dir else layout._root
+    return root / path
 
 
 def generate_report(output_dir, **entities):

--- a/src/skullduggery/workflow.py
+++ b/src/skullduggery/workflow.py
@@ -219,9 +219,9 @@ def deface_workflow(layout, args):
 
             mask_fig_path = generate_figure_path(
                 layout,
-                report_dir,
                 serie_groupref,
                 desc="mask",
+                report_dir=report_dir,
             )
             logging.info("generating deface mosaic report: %s", mask_fig_path)
             generate_deface_mosaic_report(


### PR DESCRIPTION
avoid non-existant report_dir argument in generate_figure_path running into:

```
Traceback (most recent call last):
  File "/home/milton.camachocamach/miniconda3/envs/datalad-env/bin/skullduggery", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/data/cpip-defacing/skullduggery/src/skullduggery/run.py", line 184, in main
    success = deface_workflow(layout, args)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/cpip-defacing/skullduggery/src/skullduggery/workflow.py", line 220, in deface_workflow
    mask_fig_path = generate_figure_path(
                    ^^^^^^^^^^^^^^^^^^^^^
TypeError: generate_figure_path() got multiple values for argument 'desc'
```
This also organizes the reports into the specified `--report-dir` properly following the bids entities. If `--report-dir `not provided then a report is sent to the `.skullduggery/` folder