### PR TITLE
feat: add support for 4D sequences

### DIFF
--- a/src/skullduggery/align.py
+++ b/src/skullduggery/align.py
@@ -15,17 +15,24 @@ import numpy as np
 from nibabel.spatialimages import SpatialImage
 
 
-def first_spatial_volume(image: SpatialImage) -> SpatialImage:
-    """Return a 3D image, using the first volume when a 4D image is provided."""
+def spatial_volume(image: SpatialImage, volume_index: int = 0) -> SpatialImage:
+    """Return one 3D spatial volume from a 3D or 4D image."""
     if len(image.shape) == 3:
         return image
     if len(image.shape) != 4:
         raise ValueError(f"Expected a 3D or 4D image, got shape {image.shape}")
+    if volume_index < 0 or volume_index >= image.shape[3]:
+        raise IndexError(f"Volume index {volume_index} is outside image shape {image.shape}")
 
     header = image.header.copy()
-    data = np.asanyarray(image.dataobj)[..., 0]
+    data = np.asanyarray(image.dataobj)[..., volume_index]
     header.set_data_shape(data.shape)
     return nb.Nifti1Image(data, image.affine, header)
+
+
+def first_spatial_volume(image: SpatialImage) -> SpatialImage:
+    """Return a 3D image, using the first volume when a 4D image is provided."""
+    return spatial_volume(image)
 
 
 def _ants_dimension(image) -> int:
@@ -35,17 +42,17 @@ def _ants_dimension(image) -> int:
     return len(image.shape)
 
 
-def _first_ants_volume(image):
+def _ants_volume(image, volume_index: int = 0):
     """Return a 3D ANTs image for registration."""
     dimension = _ants_dimension(image)
     if dimension == 3:
         return image
     if dimension == 4:
-        return ants.slice_image(image, axis=3, idx=0, collapse_strategy=1)
+        return ants.slice_image(image, axis=3, idx=volume_index, collapse_strategy=1)
     raise ValueError(f"Expected a 3D or 4D image for registration, got {dimension}D")
 
 
-def registration_images(ref_ants, moving_ants):
+def registration_images(ref_ants, moving_ants, ref_volume_index: int = 0, moving_volume_index: int = 0):
     """Verify ANTs image dimensions and choose a valid 3D moving image when needed."""
     ref_dimension = _ants_dimension(ref_ants)
     moving_dimension = _ants_dimension(moving_ants)
@@ -53,11 +60,11 @@ def registration_images(ref_ants, moving_ants):
     if ref_dimension == moving_dimension == 3:
         return ref_ants, moving_ants
     if ref_dimension == moving_dimension == 4:
-        return _first_ants_volume(ref_ants), _first_ants_volume(moving_ants)
+        return _ants_volume(ref_ants, ref_volume_index), _ants_volume(moving_ants, moving_volume_index)
     if ref_dimension == 3 and moving_dimension == 4:
-        return ref_ants, _first_ants_volume(moving_ants)
+        return ref_ants, _ants_volume(moving_ants, moving_volume_index)
     if ref_dimension == 4 and moving_dimension == 3:
-        return _first_ants_volume(ref_ants), moving_ants
+        return _ants_volume(ref_ants, ref_volume_index), moving_ants
 
     raise ValueError(
         "Fixed and moving image dimensions are not compatible for registration: "
@@ -72,6 +79,8 @@ def registration_antspy(
     transform: str = "Rigid",
     initial_transform: str | None = None,
     verbose: bool = False,
+    ref_volume_index: int = 0,
+    moving_volume_index: int = 0,
 ) -> dict:
     """Register a moving image to a reference image using ANTs.
 
@@ -87,6 +96,8 @@ def registration_antspy(
         initial_transform: Optional initial transformation to use.
             If None, registration starts from identity.
         verbose: Whether to print registration progress. Defaults to False.
+        ref_volume_index: Volume index to use if the reference image is 4D.
+        moving_volume_index: Volume index to use if the moving image is 4D.
 
     Returns:
         dict: Registration result containing:
@@ -96,14 +107,19 @@ def registration_antspy(
     """
     ref_ants = ants.image_read(str(ref))
     moving_ants = ants.image_read(str(moving))
-    ref_ants, moving_ants = registration_images(ref_ants, moving_ants)
+    ref_ants, moving_ants = registration_images(
+        ref_ants,
+        moving_ants,
+        ref_volume_index=ref_volume_index,
+        moving_volume_index=moving_volume_index,
+    )
     ref_mask_ants = ants.image_read(str(ref_mask)) if ref_mask else None
 
     # coud use legacy function in ants but dev advice against:
     #     use_legacy_histogram_matching : boolean
     #     if True, use the original histogram matching in ANTs. This is not recommended, but is available for backwards
-    #     compatibilty with earlier versions, where it was always turned on. The default is False. A better implementation of
-    #     histogram matching is available in the ants.histogram_match_image2 function.
+    #     compatibilty with earlier versions, where it was always turned on. The default is False.
+    #     A better implementation of histogram matching is available in the ants.histogram_match_image2 function.
 
     moving_for_registration = ants.histogram_match_image2(
         moving_ants,

--- a/src/skullduggery/align.py
+++ b/src/skullduggery/align.py
@@ -10,6 +10,59 @@ from pathlib import Path
 
 import ants
 import ants.core.ants_image_io
+import nibabel as nb
+import numpy as np
+from nibabel.spatialimages import SpatialImage
+
+
+def first_spatial_volume(image: SpatialImage) -> SpatialImage:
+    """Return a 3D image, using the first volume when a 4D image is provided."""
+    if len(image.shape) == 3:
+        return image
+    if len(image.shape) != 4:
+        raise ValueError(f"Expected a 3D or 4D image, got shape {image.shape}")
+
+    header = image.header.copy()
+    data = np.asanyarray(image.dataobj)[..., 0]
+    header.set_data_shape(data.shape)
+    return nb.Nifti1Image(data, image.affine, header)
+
+
+def _ants_dimension(image) -> int:
+    dimension = getattr(image, "dimension", None)
+    if dimension is not None:
+        return int(dimension)
+    return len(image.shape)
+
+
+def _first_ants_volume(image):
+    """Return a 3D ANTs image for registration."""
+    dimension = _ants_dimension(image)
+    if dimension == 3:
+        return image
+    if dimension == 4:
+        return ants.slice_image(image, axis=3, idx=0, collapse_strategy=1)
+    raise ValueError(f"Expected a 3D or 4D image for registration, got {dimension}D")
+
+
+def registration_images(ref_ants, moving_ants):
+    """Verify ANTs image dimensions and choose a valid 3D moving image when needed."""
+    ref_dimension = _ants_dimension(ref_ants)
+    moving_dimension = _ants_dimension(moving_ants)
+
+    if ref_dimension == moving_dimension == 3:
+        return ref_ants, moving_ants
+    if ref_dimension == moving_dimension == 4:
+        return _first_ants_volume(ref_ants), _first_ants_volume(moving_ants)
+    if ref_dimension == 3 and moving_dimension == 4:
+        return ref_ants, _first_ants_volume(moving_ants)
+    if ref_dimension == 4 and moving_dimension == 3:
+        return _first_ants_volume(ref_ants), moving_ants
+
+    raise ValueError(
+        "Fixed and moving image dimensions are not compatible for registration: "
+        f"{ref_dimension}D fixed, {moving_dimension}D moving"
+    )
 
 
 def registration_antspy(
@@ -43,6 +96,7 @@ def registration_antspy(
     """
     ref_ants = ants.image_read(str(ref))
     moving_ants = ants.image_read(str(moving))
+    ref_ants, moving_ants = registration_images(ref_ants, moving_ants)
     ref_mask_ants = ants.image_read(str(ref_mask)) if ref_mask else None
 
     # coud use legacy function in ants but dev advice against:

--- a/src/skullduggery/align.py
+++ b/src/skullduggery/align.py
@@ -16,7 +16,21 @@ from nibabel.spatialimages import SpatialImage
 
 
 def spatial_volume(image: SpatialImage, volume_index: int = 0) -> SpatialImage:
-    """Return one 3D spatial volume from a 3D or 4D image."""
+    """Return one 3D spatial volume from a 3D or 4D image.
+
+    Args:
+        image: Nibabel image to inspect. May be 3D or 4D.
+        volume_index: Zero-based index to extract when ``image`` is 4D.
+            Ignored for 3D images.
+
+    Returns:
+        A 3D image on the same spatial grid as ``image``. For 3D inputs,
+        the original image is returned unchanged.
+
+    Raises:
+        ValueError: If ``image`` is not 3D or 4D.
+        IndexError: If ``volume_index`` is outside the 4D image range.
+    """
     if len(image.shape) == 3:
         return image
     if len(image.shape) != 4:
@@ -31,11 +45,26 @@ def spatial_volume(image: SpatialImage, volume_index: int = 0) -> SpatialImage:
 
 
 def first_spatial_volume(image: SpatialImage) -> SpatialImage:
-    """Return a 3D image, using the first volume when a 4D image is provided."""
+    """Return the first 3D spatial volume from a 3D or 4D image.
+
+    Args:
+        image: Nibabel image to inspect. May be 3D or 4D.
+
+    Returns:
+        The original 3D image, or volume 0 when ``image`` is 4D.
+    """
     return spatial_volume(image)
 
 
 def _ants_dimension(image) -> int:
+    """Return the dimensionality of an ANTs-like image.
+
+    Args:
+        image: ANTs image, or an object exposing a ``shape`` attribute.
+
+    Returns:
+        Image dimensionality as an integer.
+    """
     dimension = getattr(image, "dimension", None)
     if dimension is not None:
         return int(dimension)
@@ -43,7 +72,18 @@ def _ants_dimension(image) -> int:
 
 
 def _ants_volume(image, volume_index: int = 0):
-    """Return a 3D ANTs image for registration."""
+    """Return a 3D ANTs image for registration.
+
+    Args:
+        image: ANTs image to use for registration.
+        volume_index: Zero-based index to extract when ``image`` is 4D.
+
+    Returns:
+        A 3D ANTs image. 3D inputs are returned unchanged.
+
+    Raises:
+        ValueError: If ``image`` is not 3D or 4D.
+    """
     dimension = _ants_dimension(image)
     if dimension == 3:
         return image
@@ -53,7 +93,22 @@ def _ants_volume(image, volume_index: int = 0):
 
 
 def registration_images(ref_ants, moving_ants, ref_volume_index: int = 0, moving_volume_index: int = 0):
-    """Verify ANTs image dimensions and choose a valid 3D moving image when needed."""
+    """Verify ANTs dimensions and select 3D registration inputs.
+
+    Args:
+        ref_ants: Fixed/reference ANTs image.
+        moving_ants: Moving ANTs image.
+        ref_volume_index: Volume to use if the reference is 4D.
+        moving_volume_index: Volume to use if the moving image is 4D.
+
+    Returns:
+        Tuple of ``(reference_image, moving_image)`` suitable for ANTs
+        3D registration.
+
+    Raises:
+        ValueError: If image dimensions cannot be reduced to compatible
+        3D registration inputs.
+    """
     ref_dimension = _ants_dimension(ref_ants)
     moving_dimension = _ants_dimension(moving_ants)
 

--- a/src/skullduggery/bids.py
+++ b/src/skullduggery/bids.py
@@ -52,7 +52,16 @@ def _bids_filter(json_str: str) -> dict | list:
 
 
 def create_bids_layout(args: argparse.Namespace) -> bids.BIDSLayout:
-    """Create the BIDS layout with the requested validation strictness."""
+    """Create the BIDS layout with the requested validation strictness.
+
+    Args:
+        args: Parsed CLI arguments with ``bids_path`` and
+            ``no_strict_bids_validation`` attributes.
+
+    Returns:
+        PyBIDS layout rooted at ``args.bids_path``. Validation is disabled
+        when ``--no-strict-bids-validation`` was requested.
+    """
     return bids.BIDSLayout(
         os.path.abspath(args.bids_path),
         validate=not args.no_strict_bids_validation,

--- a/src/skullduggery/bids.py
+++ b/src/skullduggery/bids.py
@@ -6,10 +6,12 @@ layouts using pyBIDS, including filtering utilities for query wildcards.
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 from pathlib import Path
 
+import bids
 from bids.layout import Query
 
 
@@ -47,3 +49,11 @@ def _bids_filter(json_str: str) -> dict | list:
     if os.path.exists(os.path.abspath(json_str)):
         json_str = Path(json_str).read_text()
     return json.loads(json_str, object_hook=_filter_pybids_any)
+
+
+def create_bids_layout(args: argparse.Namespace) -> bids.BIDSLayout:
+    """Create the BIDS layout with the requested validation strictness."""
+    return bids.BIDSLayout(
+        os.path.abspath(args.bids_path),
+        validate=not args.no_strict_bids_validation,
+    )

--- a/src/skullduggery/mask.py
+++ b/src/skullduggery/mask.py
@@ -13,7 +13,16 @@ import numpy as np
 
 
 def _mask_for_image(mask: SpatialImage, image: SpatialImage) -> SpatialImage:
-    """Return mask data sampled onto the target image grid."""
+    """Return mask data sampled onto the target image grid.
+
+    Args:
+        mask: 3D or 4D binary mask image.
+        image: Target image whose spatial grid should receive the mask.
+
+    Returns:
+        ``mask`` unchanged when it already matches ``image``. Otherwise,
+        a nearest-neighbor 3D mask sampled onto the target spatial grid.
+    """
     if (
         len(mask.shape) == 4
         and len(image.shape) == 4
@@ -88,6 +97,17 @@ def generate_deface_ear_mask(
 
 
 def mask_nifti(input, mask):
+    """Apply a 3D or 4D mask to a NIfTI-like image.
+
+    Args:
+        input: Image to deface. May be 3D or 4D.
+        mask: Binary mask sampled on the input image grid. A 3D mask is
+            broadcast across 4D input volumes; a 4D mask is applied
+            volume-by-volume.
+
+    Returns:
+        NIfTI image with masked data and the input affine/header.
+    """
     input_data = np.asanyarray(input.dataobj)
     mask_data = np.asanyarray(mask.dataobj)
     while mask_data.ndim < input_data.ndim:

--- a/src/skullduggery/mask.py
+++ b/src/skullduggery/mask.py
@@ -14,6 +14,13 @@ import numpy as np
 
 def _mask_for_image(mask: SpatialImage, image: SpatialImage) -> SpatialImage:
     """Return mask data sampled onto the target image grid."""
+    if (
+        len(mask.shape) == 4
+        and len(image.shape) == 4
+        and mask.shape == image.shape
+        and np.allclose(mask.affine, image.affine)
+    ):
+        return mask
     image_shape = image.shape[:3] if len(image.shape) == 4 else image.shape
     if mask.shape == image_shape and np.allclose(mask.affine, image.affine):
         return mask

--- a/src/skullduggery/mask.py
+++ b/src/skullduggery/mask.py
@@ -6,10 +6,17 @@ while preserving brain tissue, using template-based hard-coded anatomical marker
 
 from __future__ import annotations
 
+import logging
+
 import nibabel as nb
 from nibabel.processing import resample_from_to
 from nibabel.spatialimages import SpatialImage
+import nitransforms as nt
 import numpy as np
+
+from .align import registration_antspy, spatial_volume
+
+logger = logging.getLogger(__name__)
 
 
 def _mask_for_image(mask: SpatialImage, image: SpatialImage) -> SpatialImage:
@@ -34,6 +41,148 @@ def _mask_for_image(mask: SpatialImage, image: SpatialImage) -> SpatialImage:
     if mask.shape == image_shape and np.allclose(mask.affine, image.affine):
         return mask
     return resample_from_to(mask, (image_shape, image.affine), order=0)
+
+
+def _volume_count(image: SpatialImage) -> int:
+    """Return the number of spatial volumes in a 3D or 4D image.
+
+    Args:
+        image: Nibabel image to inspect.
+
+    Returns:
+        ``1`` for a 3D image, or the fourth-dimension length for a 4D image.
+
+    Raises:
+        ValueError: If ``image`` is not 3D or 4D.
+    """
+    if len(image.shape) == 3:
+        return 1
+    if len(image.shape) == 4:
+        return image.shape[3]
+    raise ValueError(f"Expected a 3D or 4D image, got shape {image.shape}")
+
+
+def _stack_like_reference(
+    volumes: list[SpatialImage],
+    reference: SpatialImage,
+    dtype: np.dtype | type | None = None,
+) -> SpatialImage:
+    """Stack 3D volumes into a 4D image when the reference is 4D.
+
+    Args:
+        volumes: Per-volume 3D images already sampled on the reference grid.
+        reference: Image whose shape, affine, and header should define the
+            returned image. A 3D reference returns the first input volume.
+        dtype: Optional dtype to use for the stacked data and output header.
+
+    Returns:
+        A 3D image when ``reference`` is 3D, otherwise a 4D image with one
+        input volume per fourth-dimension frame.
+    """
+    if len(reference.shape) == 3:
+        return volumes[0]
+
+    data = np.stack([np.asanyarray(volume.dataobj) for volume in volumes], axis=-1)
+    if dtype is not None:
+        data = data.astype(dtype)
+    header = reference.header.copy()
+    header.set_data_shape(data.shape)
+    if dtype is not None:
+        header.set_data_dtype(dtype)
+    return nb.Nifti1Image(data, reference.affine, header)
+
+
+def build_series_deface_mask(
+    ref_image,
+    ref_image_nb: SpatialImage,
+    serie,
+    serie_nb: SpatialImage,
+    ref_to_tpl_tx: nt.base.TransformBase,
+    ref_deface_mask: SpatialImage,
+    tpl_nb: SpatialImage,
+    verbose: bool = False,
+) -> tuple[SpatialImage, SpatialImage, str]:
+    """Build native-space deface masks and report references for one series.
+
+    Each 4D volume is registered independently to the participant reference
+    image. The participant reference-space deface mask is then resampled onto
+    that volume's native grid.
+
+    Args:
+        ref_image: PyBIDS file for the participant reference image.
+        ref_image_nb: Loaded participant reference image.
+        serie: PyBIDS file for the target series being defaced.
+        serie_nb: Loaded target series image. May be 3D or 4D.
+        ref_to_tpl_tx: Linear transform between the participant reference and
+            selected template, used for reference report rendering.
+        ref_deface_mask: Deface mask already sampled in participant reference
+            image space.
+        tpl_nb: Loaded selected template image for QA report rendering.
+        verbose: Whether ANTs registration should emit verbose output.
+
+    Returns:
+        Tuple ``(serie_mask, registered_ref, desc)`` where ``serie_mask`` is
+        sampled on the target series grid, ``registered_ref`` is a 3D/4D QA
+        reference image sampled on the same grid, and ``desc`` is the figure
+        description label.
+    """
+    volume_masks = []
+    registered_refs = []
+    volume_total = _volume_count(serie_nb)
+
+    for volume_index in range(volume_total):
+        if volume_total > 1:
+            logger.info(
+                "registering volume %d/%d of %s to reference",
+                volume_index + 1,
+                volume_total,
+                serie.relpath,
+            )
+
+        volume_reference = spatial_volume(serie_nb, volume_index)
+
+        if serie.path == ref_image.path:
+            series_to_ref_tx = nt.linear.Affine()
+        else:
+            serie2ref_reg = registration_antspy(
+                ref_image.path,
+                serie.path,
+                transform="Rigid",
+                initial_transform="Identity",
+                verbose=verbose,
+                moving_volume_index=volume_index,
+            )
+            serie2ref_tx = nt.linear.load(serie2ref_reg["fwdtransforms"][0])
+            series_to_ref_tx = nt.linear.Affine(np.linalg.inv(serie2ref_tx.matrix))
+
+        volume_mask = nt.resampling.apply(
+            series_to_ref_tx,
+            ref_deface_mask,
+            reference=volume_reference,
+            order=0,
+            output_dtype=np.uint8,
+        )
+        volume_masks.append(volume_mask)
+
+        if serie == ref_image:
+            logger.debug("generating registered template image")
+            tpl_to_ref_tx = nt.linear.Affine(np.linalg.inv(ref_to_tpl_tx.matrix))
+            registered_ref = nt.resampling.apply(tpl_to_ref_tx, tpl_nb, reference=volume_reference)
+            groupref_desc = "registration"
+        else:
+            logger.debug("generating registered reference image")
+            registered_ref = nt.resampling.apply(
+                series_to_ref_tx,
+                spatial_volume(ref_image_nb),
+                reference=volume_reference,
+            )
+            registered_ref = mask_nifti(registered_ref, volume_mask)
+            groupref_desc = "mask"
+        registered_refs.append(registered_ref)
+
+    serie_mask = _stack_like_reference(volume_masks, serie_nb, dtype=np.uint8)
+    registered_ref = _stack_like_reference(registered_refs, serie_nb)
+    return serie_mask, registered_ref, groupref_desc
 
 
 def generate_deface_ear_mask(

--- a/src/skullduggery/mask.py
+++ b/src/skullduggery/mask.py
@@ -14,9 +14,10 @@ import numpy as np
 
 def _mask_for_image(mask: SpatialImage, image: SpatialImage) -> SpatialImage:
     """Return mask data sampled onto the target image grid."""
-    if mask.shape == image.shape and np.allclose(mask.affine, image.affine):
+    image_shape = image.shape[:3] if len(image.shape) == 4 else image.shape
+    if mask.shape == image_shape and np.allclose(mask.affine, image.affine):
         return mask
-    return resample_from_to(mask, image, order=0)
+    return resample_from_to(mask, (image_shape, image.affine), order=0)
 
 
 def generate_deface_ear_mask(
@@ -80,8 +81,12 @@ def generate_deface_ear_mask(
 
 
 def mask_nifti(input, mask):
+    input_data = np.asanyarray(input.dataobj)
+    mask_data = np.asanyarray(mask.dataobj)
+    while mask_data.ndim < input_data.ndim:
+        mask_data = mask_data[..., np.newaxis]
     return nb.Nifti1Image(
-        np.asanyarray(input.dataobj) * np.asanyarray(mask.dataobj),
+        input_data * mask_data,
         input.affine,
         input.header,
     )

--- a/src/skullduggery/report.py
+++ b/src/skullduggery/report.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 import bids
+import nibabel as nb
 import nireports.assembler.report
 from nibabel.spatialimages import SpatialImage
 from nireports.assembler import data as nr_data
@@ -21,6 +22,120 @@ from nireports.reportlets.utils import compose_view
 from nireports.reportlets.mosaic import plot_segs
 
 default_path_patterns = None
+
+FALLBACK_FIGURE_ENTITY_ORDER = (
+    "subject",
+    "session",
+    "task",
+    "acquisition",
+    "ceagent",
+    "reconstruction",
+    "direction",
+    "run",
+    "echo",
+    "flip",
+    "inversion",
+    "mt",
+    "part",
+    "space",
+    "desc",
+)
+
+FALLBACK_FIGURE_ENTITY_PREFIXES = {
+    "subject": "sub",
+    "session": "ses",
+    "task": "task",
+    "acquisition": "acq",
+    "ceagent": "ce",
+    "reconstruction": "rec",
+    "direction": "dir",
+    "run": "run",
+    "echo": "echo",
+    "flip": "flip",
+    "inversion": "inv",
+    "mt": "mt",
+    "part": "part",
+    "space": "space",
+    "desc": "desc",
+}
+
+
+def _volume_image(image: SpatialImage, volume_index: int) -> SpatialImage:
+    """Return one spatial volume from a 3D or 4D image."""
+    if len(image.shape) == 3:
+        return image
+    if len(image.shape) != 4:
+        raise ValueError(f"Expected a 3D or 4D image for reporting, got shape {image.shape}")
+
+    header = image.header.copy()
+    data = image.dataobj[..., volume_index]
+    header.set_data_shape(image.shape[:3])
+    return nb.Nifti1Image(data, image.affine, header)
+
+
+def _iter_report_volumes(image: SpatialImage):
+    """Yield the 3D volumes that should be shown in the defacing report."""
+    if len(image.shape) == 3:
+        yield None, image
+        return
+    if len(image.shape) != 4:
+        raise ValueError(f"Expected a 3D or 4D image for reporting, got shape {image.shape}")
+
+    for volume_index in range(image.shape[3]):
+        yield volume_index, _volume_image(image, volume_index)
+
+
+def _matching_report_volume(image: SpatialImage, volume_index: int | None) -> SpatialImage:
+    """Return the corresponding 3D report volume, reusing 3D images for every view."""
+    if len(image.shape) == 3:
+        return image
+    if volume_index is None:
+        return _volume_image(image, 0)
+    return _volume_image(image, min(volume_index, image.shape[3] - 1))
+
+
+def _add_plot(svgs: list[str], plot_output) -> None:
+    if isinstance(plot_output, (list, tuple)):
+        svgs.extend(plot_output)
+    else:
+        svgs.append(plot_output)
+
+
+def _format_bids_entity(name: str, value: Any) -> str | None:
+    if value is None:
+        return None
+    prefix = FALLBACK_FIGURE_ENTITY_PREFIXES[name]
+    if name == "desc" and str(value).startswith("desc-"):
+        return str(value)
+    if name == "subject" and str(value).startswith("sub-"):
+        return str(value)
+    if name == "session" and str(value).startswith("ses-"):
+        return str(value)
+    return f"{prefix}-{value}"
+
+
+def _fallback_figure_path(entities: dict[str, Any]) -> Path:
+    suffix = entities.get("suffix")
+    if not suffix:
+        raise RuntimeError(f"Cannot generate a figure path without a suffix: {entities}")
+
+    filename_parts = []
+    for entity in FALLBACK_FIGURE_ENTITY_ORDER:
+        entity_part = _format_bids_entity(entity, entities.get(entity))
+        if entity_part:
+            filename_parts.append(entity_part)
+    filename_parts.append(str(suffix))
+
+    path_parts = []
+    subject = _format_bids_entity("subject", entities.get("subject"))
+    session = _format_bids_entity("session", entities.get("session"))
+    if subject:
+        path_parts.append(subject)
+    if session:
+        path_parts.append(session)
+    path_parts.append("figures")
+
+    return Path(*path_parts) / ("_".join(filename_parts) + ".svg")
 
 
 def generate_deface_mosaic_report(
@@ -45,21 +160,37 @@ def generate_deface_mosaic_report(
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    compose_view(
-        bg_svgs=(
-            plot_segs(
-                image_nii=registered_tmpl,
-                seg_niis=[warped_mask],
-                bbox_nii=masked_image,
-                masked=True,
-                title="reference",
+    bg_svgs = []
+    fg_svgs = []
+    for volume_index, masked_volume in _iter_report_volumes(masked_image):
+        volume_label = "" if volume_index is None else f" volume {volume_index + 1}"
+        mask_volume = _matching_report_volume(warped_mask, volume_index)
+        if registered_tmpl:
+            registered_volume = _matching_report_volume(registered_tmpl, volume_index)
+            _add_plot(
+                bg_svgs,
+                plot_segs(
+                    image_nii=registered_volume,
+                    seg_niis=[mask_volume],
+                    bbox_nii=masked_volume,
+                    masked=True,
+                    title=f"reference{volume_label}",
+                ),
             )
-            if registered_tmpl
-            else []
-        ),
-        fg_svgs=plot_segs(
-            image_nii=masked_image, seg_niis=[warped_mask], bbox_nii=masked_image, masked=True, title="defaced"
-        ),
+        _add_plot(
+            fg_svgs,
+            plot_segs(
+                image_nii=masked_volume,
+                seg_niis=[mask_volume],
+                bbox_nii=masked_volume,
+                masked=True,
+                title=f"defaced{volume_label}",
+            ),
+        )
+
+    compose_view(
+        bg_svgs=bg_svgs,
+        fg_svgs=fg_svgs,
         out_file=output_path,
     )
 
@@ -104,7 +235,7 @@ def generate_figure_path(
 
     path = bids.layout.layout.build_path(entities, path_patterns=default_path_patterns)
     if not path:
-        raise RuntimeError(f"Cannot generate a figure path for {entities}")
+        path = _fallback_figure_path(entities)
     root = Path(report_dir) if report_dir else layout._root
     return root / path
 

--- a/src/skullduggery/report.py
+++ b/src/skullduggery/report.py
@@ -61,7 +61,18 @@ FALLBACK_FIGURE_ENTITY_PREFIXES = {
 
 
 def _volume_image(image: SpatialImage, volume_index: int) -> SpatialImage:
-    """Return one spatial volume from a 3D or 4D image."""
+    """Return one spatial volume from a 3D or 4D image.
+
+    Args:
+        image: Image to use for report plotting.
+        volume_index: Zero-based index to extract when ``image`` is 4D.
+
+    Returns:
+        A 3D image suitable for ``plot_segs``.
+
+    Raises:
+        ValueError: If ``image`` is not 3D or 4D.
+    """
     if len(image.shape) == 3:
         return image
     if len(image.shape) != 4:
@@ -74,7 +85,18 @@ def _volume_image(image: SpatialImage, volume_index: int) -> SpatialImage:
 
 
 def _iter_report_volumes(image: SpatialImage):
-    """Yield the 3D volumes that should be shown in the defacing report."""
+    """Yield the 3D volumes that should be shown in the defacing report.
+
+    Args:
+        image: 3D or 4D image to render in a report.
+
+    Yields:
+        Tuples of ``(volume_index, volume_image)``. ``volume_index`` is
+        ``None`` for 3D images and zero-based for 4D images.
+
+    Raises:
+        ValueError: If ``image`` is not 3D or 4D.
+    """
     if len(image.shape) == 3:
         yield None, image
         return
@@ -86,7 +108,17 @@ def _iter_report_volumes(image: SpatialImage):
 
 
 def _matching_report_volume(image: SpatialImage, volume_index: int | None) -> SpatialImage:
-    """Return the corresponding 3D report volume, reusing 3D images for every view."""
+    """Return the corresponding 3D report volume for another report image.
+
+    Args:
+        image: 3D or 4D image that should match the currently plotted volume.
+        volume_index: Volume index from ``_iter_report_volumes``. ``None``
+            indicates that the primary report image is 3D.
+
+    Returns:
+        A 3D image. 3D inputs are reused for every volume; 4D inputs are
+        indexed by ``volume_index``.
+    """
     if len(image.shape) == 3:
         return image
     if volume_index is None:
@@ -95,6 +127,15 @@ def _matching_report_volume(image: SpatialImage, volume_index: int | None) -> Sp
 
 
 def _add_plot(svgs: list[str], plot_output) -> None:
+    """Append one or more SVG fragments returned by ``plot_segs``.
+
+    Args:
+        svgs: List that will be modified in place.
+        plot_output: A single SVG fragment, or an iterable of fragments.
+
+    Returns:
+        None. ``svgs`` is updated in place.
+    """
     if isinstance(plot_output, (list, tuple)):
         svgs.extend(plot_output)
     else:
@@ -102,6 +143,16 @@ def _add_plot(svgs: list[str], plot_output) -> None:
 
 
 def _format_bids_entity(name: str, value: Any) -> str | None:
+    """Format one entity as a BIDS filename component.
+
+    Args:
+        name: Entity name from ``FALLBACK_FIGURE_ENTITY_PREFIXES``.
+        value: Entity value from PyBIDS.
+
+    Returns:
+        A formatted component such as ``sub-01`` or ``acq-ihmtrage``, or
+        ``None`` when ``value`` is missing.
+    """
     if value is None:
         return None
     prefix = FALLBACK_FIGURE_ENTITY_PREFIXES[name]
@@ -115,6 +166,17 @@ def _format_bids_entity(name: str, value: Any) -> str | None:
 
 
 def _fallback_figure_path(entities: dict[str, Any]) -> Path:
+    """Build a BIDS-like figure path when PyBIDS cannot.
+
+    Args:
+        entities: PyBIDS entities for the source image plus figure metadata.
+
+    Returns:
+        Relative path under ``sub-*/ses-*/figures`` with a ``.svg`` suffix.
+
+    Raises:
+        RuntimeError: If the entities do not include an image suffix.
+    """
     suffix = entities.get("suffix")
     if not suffix:
         raise RuntimeError(f"Cannot generate a figure path without a suffix: {entities}")
@@ -153,6 +215,8 @@ def generate_deface_mosaic_report(
         masked_image: Defaced anatomical image as nibabel SpatialImage.
         warped_mask: Defacing mask in native image space as nibabel SpatialImage.
         output_path: Path where SVG output will be saved.
+        registered_tmpl: Optional reference/template image already sampled on
+            the same grid as ``masked_image`` for side-by-side QA.
 
     Raises:
         OSError: If parent directory cannot be created or file cannot be written.

--- a/src/skullduggery/run.py
+++ b/src/skullduggery/run.py
@@ -14,7 +14,7 @@ import sys
 import bids
 import coloredlogs
 
-from .bids import _bids_filter
+from .bids import _bids_filter, create_bids_layout
 from .utils import SUPPORTED_AGE_UNITS
 from .workflow import deface_workflow
 
@@ -112,6 +112,11 @@ def parse_args():
         help="Force pyBIDS reset_database and reindexing",
     )
     parser.add_argument(
+        "--no-strict-bids-validation",
+        action="store_true",
+        help="Disable strict PyBIDS validation to include non-standard filenames or suffixes.",
+    )
+    parser.add_argument(
         "--datalad",
         action="store_true",
         help="Update distribution-restrictions metadata and commit changes",
@@ -179,7 +184,7 @@ def main() -> None:
         handler.setFormatter(formatter)
         package_logger.addHandler(handler)
 
-    layout = bids.BIDSLayout(os.path.abspath(args.bids_path))
+    layout = create_bids_layout(args)
     success = False
 
     success = deface_workflow(layout, args)

--- a/src/skullduggery/workflow.py
+++ b/src/skullduggery/workflow.py
@@ -9,19 +9,17 @@ from __future__ import annotations
 import argparse
 import logging
 import os
-import tempfile
 from pathlib import Path
 from shutil import copyfile
 from importlib import resources
 
 import bids
 import nibabel as nb
-from nibabel.processing import resample_from_to
 import nitransforms as nt
 import numpy as np
 
-from .align import first_spatial_volume, registration_antspy
-from .mask import _mask_for_image, generate_deface_ear_mask, mask_nifti
+from .align import spatial_volume, registration_antspy
+from .mask import mask_nifti
 from .report import generate_deface_mosaic_report, generate_figure_path, generate_report
 from .template import get_template, select_template_by_age
 from .utils import get_age_and_unit, group_series, filters_query
@@ -50,6 +48,99 @@ def _compose_transform_chain(*transforms: nt.base.TransformBase | None) -> nt.ba
     if len(chain_transforms) == 1:
         return chain_transforms[0]
     return nt.manip.TransformChain(chain_transforms)
+
+
+def _volume_count(image: nb.spatialimages.SpatialImage) -> int:
+    """Return the number of spatial volumes in a 3D or 4D image."""
+    if len(image.shape) == 3:
+        return 1
+    if len(image.shape) == 4:
+        return image.shape[3]
+    raise ValueError(f"Expected a 3D or 4D image, got shape {image.shape}")
+
+
+def _stack_like_reference(
+    volumes: list[nb.spatialimages.SpatialImage],
+    reference: nb.spatialimages.SpatialImage,
+    dtype: np.dtype | type | None = None,
+) -> nb.spatialimages.SpatialImage:
+    """Stack 3D volumes into a 4D image when the reference is 4D."""
+    if len(reference.shape) == 3:
+        return volumes[0]
+
+    data = np.stack([np.asanyarray(volume.dataobj) for volume in volumes], axis=-1)
+    if dtype is not None:
+        data = data.astype(dtype)
+    header = reference.header.copy()
+    header.set_data_shape(data.shape)
+    if dtype is not None:
+        header.set_data_dtype(dtype)
+    return nb.Nifti1Image(data, reference.affine, header)
+
+
+def _build_series_deface_mask(
+    ref_image,
+    ref_image_nb: nb.spatialimages.SpatialImage,
+    serie,
+    serie_nb: nb.spatialimages.SpatialImage,
+    ref_to_tpl_tx: nt.base.TransformBase,
+    default_tpl_to_tpl_tx: nt.base.TransformBase | None,
+    default_tpl_defacemask: nb.spatialimages.SpatialImage,
+    tpl_nb: nb.spatialimages.SpatialImage,
+    verbose: bool = False,
+) -> tuple[nb.spatialimages.SpatialImage, nb.spatialimages.SpatialImage, str]:
+    """Register each series volume to the reference and return native masks for defacing/reporting."""
+    volume_masks = []
+    registered_refs = []
+    volume_total = _volume_count(serie_nb)
+
+    for volume_index in range(volume_total):
+        if volume_total > 1:
+            logger.info(
+                "registering volume %d/%d of %s to reference",
+                volume_index + 1,
+                volume_total,
+                serie.relpath,
+            )
+
+        serie2ref_reg = registration_antspy(
+            ref_image.path,
+            serie.path,
+            transform="Rigid",
+            initial_transform="Identity",
+            verbose=verbose,
+            moving_volume_index=volume_index,
+        )
+        serie2ref_tx = nt.linear.load(serie2ref_reg["fwdtransforms"][0])
+
+        series2template = nt.manip.TransformChain([ref_to_tpl_tx, serie2ref_tx])
+        template2series = nt.linear.Affine(np.linalg.inv(series2template.asaffine().matrix))
+        default_template2series = _compose_transform_chain(default_tpl_to_tpl_tx, template2series)
+        volume_reference = spatial_volume(serie_nb, volume_index)
+        volume_mask = nt.resampling.apply(
+            default_template2series,
+            default_tpl_defacemask,
+            reference=volume_reference,
+            order=0,
+            output_dtype=np.uint8,
+        )
+        volume_masks.append(volume_mask)
+
+        if serie == ref_image:
+            logger.debug("generating registered template image")
+            registered_ref = nt.resampling.apply(template2series, tpl_nb, reference=volume_reference)
+            groupref_desc = "registration"
+        else:
+            logger.debug("generating registered reference image")
+            ref2serie_tx = nt.linear.Affine(np.linalg.inv(serie2ref_tx.matrix))
+            registered_ref = nt.resampling.apply(ref2serie_tx, ref_image_nb, reference=volume_reference)
+            registered_ref = mask_nifti(registered_ref, volume_mask)
+            groupref_desc = "mask"
+        registered_refs.append(registered_ref)
+
+    serie_mask = _stack_like_reference(volume_masks, serie_nb, dtype=np.uint8)
+    registered_ref = _stack_like_reference(registered_refs, serie_nb)
+    return serie_mask, registered_ref, groupref_desc
 
 
 def deface_workflow(layout: bids.BIDSLayout, args: argparse.Namespace) -> bool:
@@ -106,7 +197,9 @@ def deface_workflow(layout: bids.BIDSLayout, args: argparse.Namespace) -> bool:
     default_tpl, _, _ = get_template()
     default_tpl_nb = nb.load(default_tpl)
     #default_tpl_defacemask = generate_deface_ear_mask(default_tpl_nb)
-    default_deface_mask_path = resources.files("skullduggery.data").joinpath("tpl-MNI152NLin6Asym_desc-deface_mask.nii.gz")
+    default_deface_mask_path = resources.files("skullduggery.data").joinpath(
+        "tpl-MNI152NLin6Asym_desc-deface_mask.nii.gz"
+    )
     default_tpl_defacemask = nb.load(default_deface_mask_path)
 
     # lookup reference images
@@ -178,7 +271,7 @@ def deface_workflow(layout: bids.BIDSLayout, args: argparse.Namespace) -> bool:
                 ref_image.path,
                 transform="TRSAA",
                 ref_mask=tpl_mask,
-                verbose=args.debug_level.upper == "DEBUG",
+                verbose=args.debug_level.upper() == "DEBUG",
             )
             copyfile(reg["fwdtransforms"][0], matrix_path)
             new_files.append(matrix_path)
@@ -204,31 +297,21 @@ def deface_workflow(layout: bids.BIDSLayout, args: argparse.Namespace) -> bool:
                 group_paths = [gs.path for gs in grouped_series]
                 dlad_ds.get(group_paths)
                 annex_repo.unlock(group_paths)
-            serie_groupref_nb = serie_groupref.get_image()
-
-            serie2ref_reg = registration_antspy(
-                ref_image.path, serie_groupref.path, transform="Rigid", initial_transform="Identity"
-            )
-            serie2ref_tx = nt.linear.load(serie2ref_reg["fwdtransforms"][0])
-
-            series2template = nt.manip.TransformChain([ref_to_tpl_tx, serie2ref_tx])
-            #            series2default_template = nt.manip.TransformChain(tpl_to_default_tpl + [ref_to_tpl_tx, serie2ref_tx])
-            template2series = nt.linear.Affine(np.linalg.inv(series2template.asaffine().matrix))
-            #            default_template2series = nt.linear.Affine(np.linalg.inv(series2default_template.asaffine().matrix))
-            default_template2series = _compose_transform_chain(default_tpl_to_tpl_tx, template2series)
-            warped_mask = nt.resampling.apply(
-                default_template2series,
-                default_tpl_defacemask,
-                reference=first_spatial_volume(serie_groupref_nb),
-                order=0,
-                output_dtype=np.uint8,
-            )
 
             report_inputs = []
-            groupref_report_input = None
             for serie in grouped_series:
                 serie_nb = serie.get_image()
-                serie_mask = _mask_for_image(warped_mask, serie_nb)
+                serie_mask, registered_ref, desc = _build_series_deface_mask(
+                    ref_image,
+                    ref_image_nb,
+                    serie,
+                    serie_nb,
+                    ref_to_tpl_tx,
+                    default_tpl_to_tpl_tx,
+                    default_tpl_defacemask,
+                    tpl_nb,
+                    verbose=args.debug_level.upper() == "DEBUG",
+                )
 
                 if args.save_all_masks or serie == ref_image:
                     warped_mask_path = Path(
@@ -245,44 +328,13 @@ def deface_workflow(layout: bids.BIDSLayout, args: argparse.Namespace) -> bool:
                     serie_mask.to_filename(warped_mask_path)
 
                 masked_serie = mask_nifti(serie_nb, serie_mask)
-                report_input = (serie, serie_nb, serie_mask, masked_serie)
+                report_input = (serie, serie_mask, masked_serie, registered_ref, desc)
                 report_inputs.append(report_input)
-                if serie == serie_groupref:
-                    groupref_report_input = report_input
                 masked_serie.to_filename(serie.path)
                 modified_files.append(serie.path)
                 processed_series_paths.add(serie.path)
 
-            if groupref_report_input is None:
-                raise RuntimeError(f"Could not find group reference series in grouped series: {serie_groupref.path}")
-
-            _, _, groupref_mask, masked_groupref_report = groupref_report_input
-            groupref_mask_report = first_spatial_volume(groupref_mask)
-            masked_groupref_report = first_spatial_volume(masked_groupref_report)
-            if serie_groupref == ref_image:
-                logger.debug("generating registered template image")
-                # reg to template
-                registered_groupref = nt.resampling.apply(template2series, tpl_nb, reference=masked_groupref_report)
-                groupref_desc = "registration"
-            else:
-                # reg to ref series
-                logger.debug("generating registered reference image")
-                ref2serie_tx = nt.linear.Affine(np.linalg.inv(serie2ref_tx.matrix))
-                registered_groupref = nt.resampling.apply(ref2serie_tx, ref_image_nb, reference=masked_groupref_report)
-                registered_groupref = mask_nifti(registered_groupref, groupref_mask_report)
-                groupref_desc = "mask"
-
-            for serie, serie_nb, serie_mask, masked_serie in report_inputs:
-                serie_mask_report = first_spatial_volume(serie_mask)
-                masked_serie_report = first_spatial_volume(masked_serie)
-                if serie == serie_groupref:
-                    registered_ref = registered_groupref
-                    desc = groupref_desc
-                else:
-                    registered_ref = resample_from_to(registered_groupref, masked_serie_report)
-                    registered_ref = mask_nifti(registered_ref, serie_mask_report)
-                    desc = "registration" if serie == ref_image else "mask"
-
+            for serie, serie_mask, masked_serie, registered_ref, desc in report_inputs:
                 mask_fig_path = generate_figure_path(
                     layout,
                     serie,
@@ -292,7 +344,7 @@ def deface_workflow(layout: bids.BIDSLayout, args: argparse.Namespace) -> bool:
                 logger.info("generating deface mosaic report: %s", mask_fig_path)
                 generate_deface_mosaic_report(
                     masked_serie,
-                    serie_mask_report,
+                    serie_mask,
                     mask_fig_path,
                     registered_tmpl=registered_ref,
                 )

--- a/src/skullduggery/workflow.py
+++ b/src/skullduggery/workflow.py
@@ -20,7 +20,7 @@ from nibabel.processing import resample_from_to
 import nitransforms as nt
 import numpy as np
 
-from .align import registration_antspy
+from .align import first_spatial_volume, registration_antspy
 from .mask import _mask_for_image, generate_deface_ear_mask, mask_nifti
 from .report import generate_deface_mosaic_report, generate_figure_path, generate_report
 from .template import get_template, select_template_by_age
@@ -219,7 +219,7 @@ def deface_workflow(layout: bids.BIDSLayout, args: argparse.Namespace) -> bool:
             warped_mask = nt.resampling.apply(
                 default_template2series,
                 default_tpl_defacemask,
-                reference=serie_groupref_nb,
+                reference=first_spatial_volume(serie_groupref_nb),
                 order=0,
                 output_dtype=np.uint8,
             )
@@ -257,6 +257,8 @@ def deface_workflow(layout: bids.BIDSLayout, args: argparse.Namespace) -> bool:
                 raise RuntimeError(f"Could not find group reference series in grouped series: {serie_groupref.path}")
 
             _, _, groupref_mask, masked_groupref_report = groupref_report_input
+            groupref_mask_report = first_spatial_volume(groupref_mask)
+            masked_groupref_report = first_spatial_volume(masked_groupref_report)
             if serie_groupref == ref_image:
                 logger.debug("generating registered template image")
                 # reg to template
@@ -267,16 +269,18 @@ def deface_workflow(layout: bids.BIDSLayout, args: argparse.Namespace) -> bool:
                 logger.debug("generating registered reference image")
                 ref2serie_tx = nt.linear.Affine(np.linalg.inv(serie2ref_tx.matrix))
                 registered_groupref = nt.resampling.apply(ref2serie_tx, ref_image_nb, reference=masked_groupref_report)
-                registered_groupref = mask_nifti(registered_groupref, groupref_mask)
+                registered_groupref = mask_nifti(registered_groupref, groupref_mask_report)
                 groupref_desc = "mask"
 
             for serie, serie_nb, serie_mask, masked_serie in report_inputs:
+                serie_mask_report = first_spatial_volume(serie_mask)
+                masked_serie_report = first_spatial_volume(masked_serie)
                 if serie == serie_groupref:
                     registered_ref = registered_groupref
                     desc = groupref_desc
                 else:
-                    registered_ref = resample_from_to(registered_groupref, serie_nb)
-                    registered_ref = mask_nifti(registered_ref, serie_mask)
+                    registered_ref = resample_from_to(registered_groupref, masked_serie_report)
+                    registered_ref = mask_nifti(registered_ref, serie_mask_report)
                     desc = "registration" if serie == ref_image else "mask"
 
                 mask_fig_path = generate_figure_path(
@@ -288,7 +292,7 @@ def deface_workflow(layout: bids.BIDSLayout, args: argparse.Namespace) -> bool:
                 logger.info("generating deface mosaic report: %s", mask_fig_path)
                 generate_deface_mosaic_report(
                     masked_serie,
-                    serie_mask,
+                    serie_mask_report,
                     mask_fig_path,
                     registered_tmpl=registered_ref,
                 )

--- a/src/skullduggery/workflow.py
+++ b/src/skullduggery/workflow.py
@@ -33,7 +33,19 @@ except ImportError:
 
 
 def _compose_transform_chain(*transforms: nt.base.TransformBase | None) -> nt.base.TransformBase:
-    """Compose transforms without mutating reusable TransformChain instances."""
+    """Compose transforms without mutating reusable TransformChain instances.
+
+    Args:
+        transforms: Transform objects or transform chains in application
+            order. ``None`` values are ignored.
+
+    Returns:
+        A single transform when one usable transform is provided, otherwise
+        a new ``TransformChain`` containing the flattened transforms.
+
+    Raises:
+        ValueError: If all provided transforms are ``None``.
+    """
     chain_transforms = []
     for transform in transforms:
         if transform is None:
@@ -51,7 +63,17 @@ def _compose_transform_chain(*transforms: nt.base.TransformBase | None) -> nt.ba
 
 
 def _volume_count(image: nb.spatialimages.SpatialImage) -> int:
-    """Return the number of spatial volumes in a 3D or 4D image."""
+    """Return the number of spatial volumes in a 3D or 4D image.
+
+    Args:
+        image: Nibabel image to inspect.
+
+    Returns:
+        ``1`` for a 3D image, or the fourth-dimension length for a 4D image.
+
+    Raises:
+        ValueError: If ``image`` is not 3D or 4D.
+    """
     if len(image.shape) == 3:
         return 1
     if len(image.shape) == 4:
@@ -64,7 +86,18 @@ def _stack_like_reference(
     reference: nb.spatialimages.SpatialImage,
     dtype: np.dtype | type | None = None,
 ) -> nb.spatialimages.SpatialImage:
-    """Stack 3D volumes into a 4D image when the reference is 4D."""
+    """Stack 3D volumes into a 4D image when the reference is 4D.
+
+    Args:
+        volumes: Per-volume 3D images already sampled on the reference grid.
+        reference: Image whose shape, affine, and header should define the
+            returned image. A 3D reference returns the first input volume.
+        dtype: Optional dtype to use for the stacked data and output header.
+
+    Returns:
+        A 3D image when ``reference`` is 3D, otherwise a 4D image with one
+        input volume per fourth-dimension frame.
+    """
     if len(reference.shape) == 3:
         return volumes[0]
 
@@ -88,7 +121,30 @@ def _build_series_deface_mask(
     tpl_nb: nb.spatialimages.SpatialImage,
     verbose: bool = False,
 ) -> tuple[nb.spatialimages.SpatialImage, nb.spatialimages.SpatialImage, str]:
-    """Register each series volume to the reference and return native masks for defacing/reporting."""
+    """Build native-space deface masks and report references for one series.
+
+    Each 4D volume is registered independently to the participant reference
+    image. The participant reference-space deface mask is then resampled onto
+    that volume's native grid.
+
+    Args:
+        ref_image: PyBIDS file for the participant reference image.
+        ref_image_nb: Loaded participant reference image.
+        serie: PyBIDS file for the target series being defaced.
+        serie_nb: Loaded target series image. May be 3D or 4D.
+        ref_to_tpl_tx: Linear transform between the participant reference and
+            selected template, used for reference report rendering.
+        ref_deface_mask: Deface mask already sampled in participant reference
+            image space.
+        tpl_nb: Loaded selected template image for QA report rendering.
+        verbose: Whether ANTs registration should emit verbose output.
+
+    Returns:
+        Tuple ``(serie_mask, registered_ref, desc)`` where ``serie_mask`` is
+        sampled on the target series grid, ``registered_ref`` is a 3D/4D QA
+        reference image sampled on the same grid, and ``desc`` is the figure
+        description label.
+    """
     volume_masks = []
     registered_refs = []
     volume_total = _volume_count(serie_nb)

--- a/src/skullduggery/workflow.py
+++ b/src/skullduggery/workflow.py
@@ -19,7 +19,7 @@ import nitransforms as nt
 import numpy as np
 
 from .align import spatial_volume, registration_antspy
-from .mask import mask_nifti
+from .mask import build_series_deface_mask, mask_nifti
 from .report import generate_deface_mosaic_report, generate_figure_path, generate_report
 from .template import get_template, select_template_by_age
 from .utils import get_age_and_unit, group_series, filters_query
@@ -60,148 +60,6 @@ def _compose_transform_chain(*transforms: nt.base.TransformBase | None) -> nt.ba
     if len(chain_transforms) == 1:
         return chain_transforms[0]
     return nt.manip.TransformChain(chain_transforms)
-
-
-def _volume_count(image: nb.spatialimages.SpatialImage) -> int:
-    """Return the number of spatial volumes in a 3D or 4D image.
-
-    Args:
-        image: Nibabel image to inspect.
-
-    Returns:
-        ``1`` for a 3D image, or the fourth-dimension length for a 4D image.
-
-    Raises:
-        ValueError: If ``image`` is not 3D or 4D.
-    """
-    if len(image.shape) == 3:
-        return 1
-    if len(image.shape) == 4:
-        return image.shape[3]
-    raise ValueError(f"Expected a 3D or 4D image, got shape {image.shape}")
-
-
-def _stack_like_reference(
-    volumes: list[nb.spatialimages.SpatialImage],
-    reference: nb.spatialimages.SpatialImage,
-    dtype: np.dtype | type | None = None,
-) -> nb.spatialimages.SpatialImage:
-    """Stack 3D volumes into a 4D image when the reference is 4D.
-
-    Args:
-        volumes: Per-volume 3D images already sampled on the reference grid.
-        reference: Image whose shape, affine, and header should define the
-            returned image. A 3D reference returns the first input volume.
-        dtype: Optional dtype to use for the stacked data and output header.
-
-    Returns:
-        A 3D image when ``reference`` is 3D, otherwise a 4D image with one
-        input volume per fourth-dimension frame.
-    """
-    if len(reference.shape) == 3:
-        return volumes[0]
-
-    data = np.stack([np.asanyarray(volume.dataobj) for volume in volumes], axis=-1)
-    if dtype is not None:
-        data = data.astype(dtype)
-    header = reference.header.copy()
-    header.set_data_shape(data.shape)
-    if dtype is not None:
-        header.set_data_dtype(dtype)
-    return nb.Nifti1Image(data, reference.affine, header)
-
-
-def _build_series_deface_mask(
-    ref_image,
-    ref_image_nb: nb.spatialimages.SpatialImage,
-    serie,
-    serie_nb: nb.spatialimages.SpatialImage,
-    ref_to_tpl_tx: nt.base.TransformBase,
-    ref_deface_mask: nb.spatialimages.SpatialImage,
-    tpl_nb: nb.spatialimages.SpatialImage,
-    verbose: bool = False,
-) -> tuple[nb.spatialimages.SpatialImage, nb.spatialimages.SpatialImage, str]:
-    """Build native-space deface masks and report references for one series.
-
-    Each 4D volume is registered independently to the participant reference
-    image. The participant reference-space deface mask is then resampled onto
-    that volume's native grid.
-
-    Args:
-        ref_image: PyBIDS file for the participant reference image.
-        ref_image_nb: Loaded participant reference image.
-        serie: PyBIDS file for the target series being defaced.
-        serie_nb: Loaded target series image. May be 3D or 4D.
-        ref_to_tpl_tx: Linear transform between the participant reference and
-            selected template, used for reference report rendering.
-        ref_deface_mask: Deface mask already sampled in participant reference
-            image space.
-        tpl_nb: Loaded selected template image for QA report rendering.
-        verbose: Whether ANTs registration should emit verbose output.
-
-    Returns:
-        Tuple ``(serie_mask, registered_ref, desc)`` where ``serie_mask`` is
-        sampled on the target series grid, ``registered_ref`` is a 3D/4D QA
-        reference image sampled on the same grid, and ``desc`` is the figure
-        description label.
-    """
-    volume_masks = []
-    registered_refs = []
-    volume_total = _volume_count(serie_nb)
-
-    for volume_index in range(volume_total):
-        if volume_total > 1:
-            logger.info(
-                "registering volume %d/%d of %s to reference",
-                volume_index + 1,
-                volume_total,
-                serie.relpath,
-            )
-
-        volume_reference = spatial_volume(serie_nb, volume_index)
-
-        if serie.path == ref_image.path:
-            series_to_ref_tx = nt.linear.Affine()
-        else:
-            serie2ref_reg = registration_antspy(
-                ref_image.path,
-                serie.path,
-                transform="Rigid",
-                initial_transform="Identity",
-                verbose=verbose,
-                moving_volume_index=volume_index,
-            )
-            serie2ref_tx = nt.linear.load(serie2ref_reg["fwdtransforms"][0])
-            series_to_ref_tx = nt.linear.Affine(np.linalg.inv(serie2ref_tx.matrix))
-
-        volume_mask = nt.resampling.apply(
-            series_to_ref_tx,
-            ref_deface_mask,
-            reference=volume_reference,
-            order=0,
-            output_dtype=np.uint8,
-        )
-        volume_masks.append(volume_mask)
-
-        if serie == ref_image:
-            logger.debug("generating registered template image")
-            tpl_to_ref_tx = nt.linear.Affine(np.linalg.inv(ref_to_tpl_tx.matrix))
-            registered_ref = nt.resampling.apply(tpl_to_ref_tx, tpl_nb, reference=volume_reference)
-            groupref_desc = "registration"
-        else:
-            logger.debug("generating registered reference image")
-            registered_ref = nt.resampling.apply(
-                series_to_ref_tx,
-                spatial_volume(ref_image_nb),
-                reference=volume_reference,
-            )
-            registered_ref = mask_nifti(registered_ref, volume_mask)
-            groupref_desc = "mask"
-        registered_refs.append(registered_ref)
-
-    serie_mask = _stack_like_reference(volume_masks, serie_nb, dtype=np.uint8)
-    registered_ref = _stack_like_reference(registered_refs, serie_nb)
-    return serie_mask, registered_ref, groupref_desc
 
 
 def deface_workflow(layout: bids.BIDSLayout, args: argparse.Namespace) -> bool:
@@ -371,7 +229,7 @@ def deface_workflow(layout: bids.BIDSLayout, args: argparse.Namespace) -> bool:
             report_inputs = []
             for serie in grouped_series:
                 serie_nb = serie.get_image()
-                serie_mask, registered_ref, desc = _build_series_deface_mask(
+                serie_mask, registered_ref, desc = build_series_deface_mask(
                     ref_image,
                     ref_image_nb,
                     serie,

--- a/src/skullduggery/workflow.py
+++ b/src/skullduggery/workflow.py
@@ -84,8 +84,7 @@ def _build_series_deface_mask(
     serie,
     serie_nb: nb.spatialimages.SpatialImage,
     ref_to_tpl_tx: nt.base.TransformBase,
-    default_tpl_to_tpl_tx: nt.base.TransformBase | None,
-    default_tpl_defacemask: nb.spatialimages.SpatialImage,
+    ref_deface_mask: nb.spatialimages.SpatialImage,
     tpl_nb: nb.spatialimages.SpatialImage,
     verbose: bool = False,
 ) -> tuple[nb.spatialimages.SpatialImage, nb.spatialimages.SpatialImage, str]:
@@ -103,23 +102,25 @@ def _build_series_deface_mask(
                 serie.relpath,
             )
 
-        serie2ref_reg = registration_antspy(
-            ref_image.path,
-            serie.path,
-            transform="Rigid",
-            initial_transform="Identity",
-            verbose=verbose,
-            moving_volume_index=volume_index,
-        )
-        serie2ref_tx = nt.linear.load(serie2ref_reg["fwdtransforms"][0])
-
-        series2template = nt.manip.TransformChain([ref_to_tpl_tx, serie2ref_tx])
-        template2series = nt.linear.Affine(np.linalg.inv(series2template.asaffine().matrix))
-        default_template2series = _compose_transform_chain(default_tpl_to_tpl_tx, template2series)
         volume_reference = spatial_volume(serie_nb, volume_index)
+
+        if serie.path == ref_image.path:
+            series_to_ref_tx = nt.linear.Affine()
+        else:
+            serie2ref_reg = registration_antspy(
+                ref_image.path,
+                serie.path,
+                transform="Rigid",
+                initial_transform="Identity",
+                verbose=verbose,
+                moving_volume_index=volume_index,
+            )
+            serie2ref_tx = nt.linear.load(serie2ref_reg["fwdtransforms"][0])
+            series_to_ref_tx = nt.linear.Affine(np.linalg.inv(serie2ref_tx.matrix))
+
         volume_mask = nt.resampling.apply(
-            default_template2series,
-            default_tpl_defacemask,
+            series_to_ref_tx,
+            ref_deface_mask,
             reference=volume_reference,
             order=0,
             output_dtype=np.uint8,
@@ -128,12 +129,16 @@ def _build_series_deface_mask(
 
         if serie == ref_image:
             logger.debug("generating registered template image")
-            registered_ref = nt.resampling.apply(template2series, tpl_nb, reference=volume_reference)
+            tpl_to_ref_tx = nt.linear.Affine(np.linalg.inv(ref_to_tpl_tx.matrix))
+            registered_ref = nt.resampling.apply(tpl_to_ref_tx, tpl_nb, reference=volume_reference)
             groupref_desc = "registration"
         else:
             logger.debug("generating registered reference image")
-            ref2serie_tx = nt.linear.Affine(np.linalg.inv(serie2ref_tx.matrix))
-            registered_ref = nt.resampling.apply(ref2serie_tx, ref_image_nb, reference=volume_reference)
+            registered_ref = nt.resampling.apply(
+                series_to_ref_tx,
+                spatial_volume(ref_image_nb),
+                reference=volume_reference,
+            )
             registered_ref = mask_nifti(registered_ref, volume_mask)
             groupref_desc = "mask"
         registered_refs.append(registered_ref)
@@ -276,6 +281,15 @@ def deface_workflow(layout: bids.BIDSLayout, args: argparse.Namespace) -> bool:
             copyfile(reg["fwdtransforms"][0], matrix_path)
             new_files.append(matrix_path)
         ref_to_tpl_tx = nt.linear.load(matrix_path)
+        ref_to_tpl_pull_tx = nt.linear.Affine(np.linalg.inv(ref_to_tpl_tx.matrix))
+        ref_to_default_tpl_tx = _compose_transform_chain(ref_to_tpl_pull_tx, default_tpl_to_tpl_tx)
+        ref_deface_mask = nt.resampling.apply(
+            ref_to_default_tpl_tx,
+            default_tpl_defacemask,
+            reference=spatial_volume(ref_image_nb),
+            order=0,
+            output_dtype=np.uint8,
+        )
 
         series_to_deface = filters_query(layout, subject, session, args.other_bids_filters)
 
@@ -307,8 +321,7 @@ def deface_workflow(layout: bids.BIDSLayout, args: argparse.Namespace) -> bool:
                     serie,
                     serie_nb,
                     ref_to_tpl_tx,
-                    default_tpl_to_tpl_tx,
-                    default_tpl_defacemask,
+                    ref_deface_mask,
                     tpl_nb,
                     verbose=args.debug_level.upper() == "DEBUG",
                 )


### PR DESCRIPTION
- Added --no-strict-bids-validation to allow skullduggery to detect BIDS-like suffixes even if not part of the BIDS standard yet.

- Extends the existing defacing workflow from a single moving-image transform to per-volume registration for 4D images.

   - Adds support for GE IHMT/MTR-style 4D images where volumes may differ in alignment or contrast.

   - Updates reports to display each 4D volume with its corresponding native-space mask.

   - Adds fallback figure path generation for suffix/entity combinations PyBIDS cannot build directly.
   
An example of data ran through:

<img width="2060" height="1152" alt="image" src="https://github.com/user-attachments/assets/7dd7a5fa-b5d9-43a4-bd43-dedc406c502a" />

   